### PR TITLE
Add use_connection_profiles flag to toggle pulling credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ additional_properties:
   - SiteID
 groups:
   cellular_routers: "'-4G' in inventory_hostname or '-4g' in inventory_hostname"
+use_connection_profiles: true
 ```
 
 The `additional_properties` option is a list of column names from `Cirrus.Nodes` that you want to group the inventory by. The plugin automatically retrieves these fields from `Cirrus.Nodes`:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Add a `use_connection_profiles` boolean flag to allow the option of toggling the use of Solarwinds NCM Connection Profile credentials for inventory items.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

The default for this flag is `False` so as to not leak credentials without explicitly enabling it. 

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
